### PR TITLE
Ajuste no posicionamento do rodapé

### DIFF
--- a/sgce/core/templates/includes/rodape-credito.html
+++ b/sgce/core/templates/includes/rodape-credito.html
@@ -1,4 +1,6 @@
-<footer class="footer fixed-bottom text-center">
+<br>
+<style>body,html{height:100%}.container{min-height:30%}</style>
+<footer class="footer text-center">
         <div class="footnote">
             <p class="font-weight-light">
                 O sistema <strong class="font-weight-normal">SGCE</strong> é um software livre licenciado sob <a href="https://github.com/vinigracindo/sgce/blob/master/LICENSE" rel="external">MIT License</a>.


### PR DESCRIPTION
Remoção da classe fixed-bottom e adição de css para impedir que o rodapé sobreponha os elementos da página